### PR TITLE
Fix: pause type generation on migration and Type Generation Settings for path

### DIFF
--- a/frappe_types/frappe_types/doctype/app_settings/app_settings.json
+++ b/frappe_types/frappe_types/doctype/app_settings/app_settings.json
@@ -1,0 +1,41 @@
+{
+ "actions": [],
+ "autoname": "autoincrement",
+ "creation": "2022-09-15 12:43:46.781969",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "app_name",
+  "app_path"
+ ],
+ "fields": [
+  {
+   "fieldname": "app_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "App Name",
+   "reqd": 1
+  },
+  {
+   "fieldname": "app_path",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "App Path",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2022-09-15 12:43:46.781969",
+ "modified_by": "Administrator",
+ "module": "Frappe Types",
+ "name": "App Settings",
+ "naming_rule": "Autoincrement",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe_types/frappe_types/doctype/app_settings/app_settings.py
+++ b/frappe_types/frappe_types/doctype/app_settings/app_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Nikhil Kothari and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class AppSettings(Document):
+	pass

--- a/frappe_types/frappe_types/doctype/app_type_generation_paths/app_type_generation_paths.json
+++ b/frappe_types/frappe_types/doctype/app_type_generation_paths/app_type_generation_paths.json
@@ -31,7 +31,7 @@
  "modified": "2022-09-15 12:43:46.781969",
  "modified_by": "Administrator",
  "module": "Frappe Types",
- "name": "App Settings",
+ "name": "App Type Generation Paths",
  "naming_rule": "Autoincrement",
  "owner": "Administrator",
  "permissions": [],

--- a/frappe_types/frappe_types/doctype/app_type_generation_paths/app_type_generation_paths.py
+++ b/frappe_types/frappe_types/doctype/app_type_generation_paths/app_type_generation_paths.py
@@ -4,5 +4,5 @@
 # import frappe
 from frappe.model.document import Document
 
-class AppSettings(Document):
+class AppTypeGenerationPaths(Document):
 	pass

--- a/frappe_types/frappe_types/doctype/type_generation_settings/test_type_generation_settings.py
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/test_type_generation_settings.py
@@ -1,9 +1,0 @@
-# Copyright (c) 2022, Nikhil Kothari and Contributors
-# See license.txt
-
-# import frappe
-from frappe.tests.utils import FrappeTestCase
-
-
-class TestTypeGenerationSettings(FrappeTestCase):
-	pass

--- a/frappe_types/frappe_types/doctype/type_generation_settings/test_type_generation_settings.py
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/test_type_generation_settings.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Nikhil Kothari and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestTypeGenerationSettings(FrappeTestCase):
+	pass

--- a/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.js
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2022, Nikhil Kothari and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Type Generation Settings', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.json
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.json
@@ -1,0 +1,43 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2022-09-14 19:44:07.791947",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "type_settings"
+ ],
+ "fields": [
+  {
+   "fieldname": "type_settings",
+   "fieldtype": "Table",
+   "label": "Type Settings",
+   "options": "App Settings",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "issingle": 1,
+ "links": [],
+ "modified": "2022-09-15 13:18:25.691133",
+ "modified_by": "Administrator",
+ "module": "Frappe Types",
+ "name": "Type Generation Settings",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.json
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.json
@@ -13,14 +13,14 @@
    "fieldname": "type_settings",
    "fieldtype": "Table",
    "label": "Type Settings",
-   "options": "App Settings",
+   "options": "App Type Generation Paths",
    "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-09-15 13:18:25.691133",
+ "modified": "2022-09-15 18:44:11.359578",
  "modified_by": "Administrator",
  "module": "Frappe Types",
  "name": "Type Generation Settings",

--- a/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.py
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Nikhil Kothari and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class TypeGenerationSettings(Document):
+	pass

--- a/frappe_types/frappe_types/type_generator.py
+++ b/frappe_types/frappe_types/type_generator.py
@@ -6,10 +6,6 @@ import subprocess
 
 def create_type_definition_file(doc, method=None):
 
-    # Fetch Type Generation Settings Document
-    type_generation_settings = frappe.get_doc(
-        'Type Generation Settings').as_dict().type_settings
-
     # Check if type generation is paused
     common_site_config = frappe.get_conf()
 
@@ -34,6 +30,11 @@ def create_type_definition_file(doc, method=None):
         if not app_path.exists():
             print("App path does not exist - ignoring type generation")
             return
+
+        # Fetch Type Generation Settings Document
+        type_generation_settings = frappe.get_doc(
+            'Type Generation Settings').as_dict().type_settings
+
         # Checking if app is existed in type generation settings
         for type_setting in type_generation_settings:
             if module.app_name == type_setting.app_name:

--- a/frappe_types/frappe_types/type_generator.py
+++ b/frappe_types/frappe_types/type_generator.py
@@ -1,10 +1,18 @@
 import frappe
 from pathlib import Path
 from .utils import create_file
+import subprocess
+
 
 def create_type_definition_file(doc, method=None):
     print("DocType created")
     print(doc)
+    common_site_config = frappe.get_conf()
+    frappe_types_pause_generation = common_site_config.get(
+        "frappe_types_pause_generation", 0)
+    if frappe_types_pause_generation:
+        print("Frappe Types is paused")
+        return
     doctype = frappe.get_doc("DocType", doc.name)
 
     if is_developer_mode_enabled() and is_valid_doctype(doctype):
@@ -14,7 +22,7 @@ def create_type_definition_file(doc, method=None):
         if module.app_name == "frappe" or module.app_name == "erpnext":
             print("Ignoring core app DocTypes")
             return
-            
+
         app_path: Path = Path("../apps") / module.app_name
 
         if not app_path.exists():
@@ -33,8 +41,7 @@ def create_type_definition_file(doc, method=None):
 
         generate_type_definition_file(doctype, module_path)
 
-    
-    
+
 def generate_type_definition_file(doctype, module_path):
 
     doctype_name = doctype.name.replace(" ", "")
@@ -44,10 +51,11 @@ def generate_type_definition_file(doctype, module_path):
     print("Type file content: " + str(type_file_content))
     create_file(type_file_path, type_file_content)
 
+
 def generate_type_definition_content(doctype):
     content = "export interface " + doctype.name.replace(" ", "") + "{\n"
 
-    #Boilerplate types for all documents
+    # Boilerplate types for all documents
     content += "\tcreation: string\n\tname: string\n\tmodified: string\n\towner: string\n\tmodified_by: string\n\tdocstatus: 0 | 1 | 2\n\tparent?: string\n\tparentfield?: string\n\tparenttype?: string\n\tidx?: number\n"
 
     for field in doctype.fields:
@@ -59,14 +67,19 @@ def generate_type_definition_content(doctype):
     content += "}"
     return content
 
+
 def get_field_comment(field):
     desc = field.description
     print(field.options)
     if field.fieldtype in ["Link", "Table", "Table MultiSelect"]:
-        desc = field.options + (" - " + field.description if field.description else "")
+        desc = field.options + \
+            (" - " + field.description if field.description else "")
     return "\t/**\t" + field.label + " : " + field.fieldtype + ((" - " + desc) if desc else "") + "\t*/\n"
+
+
 def get_field_type_definition(field):
     return field.fieldname + get_required(field) + ": " + get_field_type(field)
+
 
 def get_field_type(field):
 
@@ -101,10 +114,10 @@ def get_field_type(field):
         "Markdown Editor": "string",
     }
 
-    #TODO: Add support for Table and Table Multiselect - will need to add imports to file
+    # TODO: Add support for Table and Table Multiselect - will need to add imports to file
     if field.fieldtype in ["Table", "Table MultiSelect"]:
         return "any[]"
-    
+
     if field.fieldtype == "Select":
         options = field.options.split("\n")
         t = ""
@@ -113,11 +126,12 @@ def get_field_type(field):
         if t.endswith(" | "):
             t = t[:-3]
         return t
-    
+
     if field.fieldtype in basic_fieldtypes:
         return basic_fieldtypes[field.fieldtype]
     else:
         return "any"
+
 
 def get_required(field):
     if field.reqd:
@@ -125,19 +139,33 @@ def get_required(field):
     else:
         return "?"
 
+
 def is_valid_doctype(doctype):
-    if(doctype.custom):
+    if (doctype.custom):
         print("Custom DocType - ignoring type generation")
         return False
-    
-    if(doctype.is_virtual):
+
+    if (doctype.is_virtual):
         print("Virtual DocType - ignoring type generation")
         return False
-    
+
     return True
+
 
 def is_developer_mode_enabled():
     if not frappe.conf.get("developer_mode"):
         print("Developer mode not enabled - ignoring type generation")
         return False
     return True
+
+
+def before_migrate():
+    # print("Before migrate")
+    subprocess.run(
+        ["bench", "config", "set-common-config", "-c", "frappe_types_pause_generation", "1"])
+
+
+def after_migrate():
+    # print("After migrate")
+    subprocess.run(["bench", "config", "set-common-config",
+                   "-c", "frappe_types_pause_generation", "0"])

--- a/frappe_types/frappe_types/type_generator.py
+++ b/frappe_types/frappe_types/type_generator.py
@@ -5,8 +5,7 @@ import subprocess
 
 
 def create_type_definition_file(doc, method=None):
-    print("DocType created")
-    print(doc)
+
     common_site_config = frappe.get_conf()
     frappe_types_pause_generation = common_site_config.get(
         "frappe_types_pause_generation", 0)
@@ -46,9 +45,7 @@ def generate_type_definition_file(doctype, module_path):
 
     doctype_name = doctype.name.replace(" ", "")
     type_file_path = module_path / (doctype_name + ".ts")
-    print("Type file path: " + str(type_file_path))
     type_file_content = generate_type_definition_content(doctype)
-    print("Type file content: " + str(type_file_content))
     create_file(type_file_path, type_file_content)
 
 

--- a/frappe_types/hooks.py
+++ b/frappe_types/hooks.py
@@ -64,7 +64,12 @@ app_license = "MIT"
 # ------------
 
 # before_install = "frappe_types.install.before_install"
-# after_install = "frappe_types.install.after_install"
+after_install = "frappe_types.frappe_types.type_generator.after_migrate"
+
+# Migration
+
+before_migrate = "frappe_types.frappe_types.type_generator.before_migrate"
+after_migrate = "frappe_types.frappe_types.type_generator.after_migrate"
 
 # Uninstallation
 # ------------
@@ -102,10 +107,11 @@ app_license = "MIT"
 # ---------------
 # Hook on document methods and events
 
+
 doc_events = {
-	"DocType": {
-		"on_update": "frappe_types.frappe_types.type_generator.create_type_definition_file"
-	}
+    "DocType": {
+        "on_update": "frappe_types.frappe_types.type_generator.create_type_definition_file"
+    }
 }
 
 # Scheduled Tasks


### PR DESCRIPTION
frappe_types now have feature to not create types on bench update or  migrate and even it will be only run for specific app.
We created Type Generation Settings doctype which contain table with fields app_name and app_path in which we can add name of those app for which we want types generation and we can add path of types folder.

eg.{app_name: library_management, app_path: library/src }.
 
It will automatically generate types for that app on that path, this is very helpful for front-end developers as their is no need to create typescript file it will be automatically created      