### PR TITLE
fix: make app paths not mandatory

### DIFF
--- a/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.json
+++ b/frappe_types/frappe_types/doctype/type_generation_settings/type_generation_settings.json
@@ -13,14 +13,13 @@
    "fieldname": "type_settings",
    "fieldtype": "Table",
    "label": "Type Settings",
-   "options": "App Type Generation Paths",
-   "reqd": 1
+   "options": "App Type Generation Paths"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-09-15 18:44:11.359578",
+ "modified": "2022-12-29 07:35:19.201259",
  "modified_by": "Administrator",
  "module": "Frappe Types",
  "name": "Type Generation Settings",


### PR DESCRIPTION
* useful in case I don't want any type generations
